### PR TITLE
TITAN Network Module Initial Work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.galaxy-roles
+.terraform
+.vagrant
+*.tfstate

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
+# vi: set ft=ruby :
+
+require 'etc'
+require 'shellwords'
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "bento/centos-7.4"
+  config.vm.hostname = "titan"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", type: "dhcp"
+
+  # forward AWS environment variables across the wire
+  config.ssh.forward_env = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+
+  # Tweak the VMs configuration.
+  config.vm.provider "virtualbox" do |vb|
+    vb.cpus = Etc.nprocessors
+    vb.memory = 1024
+    vb.linked_clone = true
+  end
+
+  # Configure the VM using Ansible
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.galaxy_role_file = "requirements.yml"
+    ansible.galaxy_roles_path = ".galaxy-roles"
+    ansible.provisioning_path = "/vagrant"
+    ansible.playbook = "vagrant.yml"
+    # allow passing ansible args from environment variable
+    ansible.raw_arguments = Shellwords::shellwords(ENV.fetch("ANSIBLE_ARGS", ""))
+  end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+retry_files_enabled = false

--- a/examples/single/main.tf
+++ b/examples/single/main.tf
@@ -1,0 +1,24 @@
+# Single TITAN Network Example
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "template" {
+  version = "~> 0.1"
+}
+
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+module "network" {
+  source = "../../modules/aws/titan_network"
+  network_id = 1
+  name = "development"
+  name_short = "dev"
+  name_fancy = "TITAN Development Network"
+  domain = "us-east-1.mycompany.com"
+}

--- a/modules/aws/titan_network/README.md
+++ b/modules/aws/titan_network/README.md
@@ -1,0 +1,14 @@
+# TITAN Network Module
+
+This module contains the skeleton of a TITAN network.
+
+In object-oriented language, this serves as the abstract superclass of TITAN environments and TITAN hubs. All shared
+resources are declared here and extended as appropriate in the TITAN Environment module and the TITAN Hub module.
+
+For more information on these modules, please see each module's README.
+
+## Resources
+
+## Variables
+
+## Outputs

--- a/modules/aws/titan_network/data.tf
+++ b/modules/aws/titan_network/data.tf
@@ -1,0 +1,10 @@
+# TITAN Network Module - Data Providers
+
+# List of Available Availability Zones in this Region
+data "aws_availability_zones" "default" { state = "available" }
+
+# Metadata about the Current Account and User
+data "aws_caller_identity" "default" {}
+
+# The Current AWS Region
+data "aws_region" "default" { current = true }

--- a/modules/aws/titan_network/main.tf
+++ b/modules/aws/titan_network/main.tf
@@ -1,0 +1,1 @@
+# TITAN Network Module

--- a/modules/aws/titan_network/o.route53.tf
+++ b/modules/aws/titan_network/o.route53.tf
@@ -1,0 +1,84 @@
+# TITAN Network Module - Route 53 Outputs
+
+output "delegation_set_id" {
+  value = "${aws_route53_delegation_set.default.id}"
+
+  description = <<-EOF
+    Unique identifier for the Route 53 delegation set associated with the public Route 53 hosted zone for this TITAN
+    network.
+
+    See: https://www.terraform.io/docs/providers/aws/r/route53_delegation_set.html
+  EOF
+}
+
+output "delegation_set_name_servers" {
+  value = "${aws_route53_delegation_set.default.name_servers}"
+
+  description = <<-EOF
+    A set of Amazon name servers serving the public Route 53 hosted zone for this TITAN network.
+
+    Typically, these values are used with your DNS provider to delegate public DNS resolution for this TITAN network.
+
+    See: https://www.terraform.io/docs/providers/aws/r/route53_delegation_set.html
+  EOF
+}
+
+output "domain" {
+  value = "${var.domain}"
+
+  description = <<-EOF
+    Value of the `domain` variable exported for usability.
+
+    Note that this is not a FQDN ending with a period.
+  EOF
+}
+
+output "private_zone_id" {
+  value = "${aws_route53_zone.private.zone_id}"
+
+  description = <<-EOF
+    The Amazon hosted zone identifier for the private Route 53 hosted zone for this TITAN network.
+
+    See: https://www.terraform.io/docs/providers/aws/r/route53_zone.html
+  EOF
+}
+
+output "public_zone_id" {
+  value = "${aws_route53_zone.public.zone_id}"
+
+  description = <<-EOF
+    The Amazon hosted zone identifier for the public Route 53 hosted zone for this TITAN network.
+
+    See: https://www.terraform.io/docs/providers/aws/r/route53_zone.html
+  EOF
+}
+
+output "reverse_zone" {
+  value = "${var.network_id}.10.in-addr.arpa"
+
+  description = <<-EOF
+    The reverse hosted zone name for this TITAN network.
+
+    Note that this is not a FQDN ending with a period.
+  EOF
+}
+
+output "reverse_zone_id" {
+  value = "${aws_route53_zone.reverse.zone_id}"
+
+  description = <<-EOF
+    The Amazon hosted zone identifier for the reverse Route 53 hosted zone for this TITAN network.
+
+    See: https://www.terraform.io/docs/providers/aws/r/route53_zone.html
+  EOF
+}
+
+output "zone" {
+  value = "${var.name_short}.${var.domain}"
+
+  description = <<-EOF
+    The hosted zone domain name for this TITAN network.
+
+    Note that this is not a FQDN ending with a period.
+  EOF
+}

--- a/modules/aws/titan_network/o.security_groups.tf
+++ b/modules/aws/titan_network/o.security_groups.tf
@@ -1,0 +1,19 @@
+# TITAN Network Module - Security Group Outputs
+
+output "default_security_group_id" {
+  value = "${aws_vpc.default.default_security_group_id}"
+
+  description = <<-EOF
+    The default security group ID for this TITAN network's VPC.
+
+    See: https://www.terraform.io/docs/providers/aws/r/vpc.html
+  EOF
+}
+
+output "internal_ssh_sg_id" {
+  value = "${aws_security_group.ssh.id}"
+
+  description = <<-EOF
+    Security group ID of the internal SSH security group for this TITAN network.
+  EOF
+}

--- a/modules/aws/titan_network/o.sns.tf
+++ b/modules/aws/titan_network/o.sns.tf
@@ -1,0 +1,12 @@
+# TITAN Network Module - SNS Outputs
+
+output "autoscaling_sns_topic_arn" {
+  value = "${aws_sns_topic.autoscaling.arn}"
+
+  description = <<-EOF
+    ARN of the SNS autoscaling topic.
+
+    This SNS topic is intended to be attached to autoscaling groups in this TITAN network in order to provide a
+    centralized notification topic which is notified when servers are added and removed from autoscaling groups.
+  EOF
+}

--- a/modules/aws/titan_network/o.vpc.tf
+++ b/modules/aws/titan_network/o.vpc.tf
@@ -1,0 +1,186 @@
+# TITAN Network Module - VPC Outputs
+
+output "cidr_block" {
+  value = "${aws_vpc.default.cidr_block}"
+
+  description = <<-EOF
+    IPv4 CIDR block occupied by this TITAN network.
+
+    Generally this will be `10.${var.network_id}.0.0/16`.
+  EOF
+}
+
+output "default_network_acl_id" {
+  value = "${aws_vpc.default.default_network_acl_id}"
+
+  description = <<-EOF
+    The ID of the default network ACL created by AWS for this TITAN network.
+
+    See: https://www.terraform.io/docs/providers/aws/r/vpc.html
+  EOF
+}
+
+output "default_route_table_id" {
+  value = "${aws_vpc.default.default_route_table_id}"
+
+  description = <<-EOF
+    The ID of the default route table created by AWS for this TITAN network.
+
+    See: https://www.terraform.io/docs/providers/aws/r/vpc.html
+  EOF
+}
+
+output "dhcp_options_id" {
+  value = "${aws_vpc_dhcp_options.default.id}"
+
+  description = <<-EOF
+    The id of this TITAN network's DHCP options set.
+
+    See: https://www.terraform.io/docs/providers/aws/r/vpc_dhcp_options.html
+  EOF
+}
+
+output "dhcp_options_association_id" {
+  value = "${aws_vpc_dhcp_options_association.default.id}"
+
+  description = <<-EOF
+    The id of this TITAN network's DHCP options set association.
+
+    See: https://www.terraform.io/docs/providers/aws/r/vpc_dhcp_options_association.html
+  EOF
+}
+
+output "domain_name_servers" {
+  value = "${var.domain_name_servers}"
+
+  description = <<-EOF
+    A list of DNS resolvers for this TITAN network.
+
+    See: https://www.terraform.io/docs/providers/aws/r/vpc.html
+  EOF
+}
+
+output "egress_only_internet_gateway_id" {
+  value = "${aws_egress_only_internet_gateway.default.id}"
+
+  description = <<-EOF
+    ID for the IPv6 egress-only internet gateway for this TITAN network.
+  EOF
+}
+
+output "id" {
+  value = "${var.network_id}"
+
+  description = <<-EOF
+    Synonym for `network_id`, the second IP octet uniquely identifying this TITAN network.
+  EOF
+}
+
+output "instance_tenancy" {
+  value = "${var.instance_tenancy}"
+
+  description = <<-EOF
+    Instance tenancy for EC2 instances launched in this TITAN network's VPC.
+
+    See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
+  EOF
+}
+
+output "internet_gateway_id" {
+  value = "${aws_internet_gateway.default.id}"
+
+  description = <<-EOF
+    ID for the IPv4 internet gateway for this TITAN network.
+  EOF
+}
+
+output "ipv6_association_id" {
+  value = "${aws_vpc.default.ipv6_association_id}"
+
+  description = <<-EOF
+    The association ID for the IPv6 CIDR block of this TITAN network's VPC.
+  EOF
+}
+
+output "ipv6_cidr_block" {
+  value = "${aws_vpc.default.ipv6_cidr_block}"
+
+  description = <<-EOF
+    The IPv6 CIDR block automatically assigned to this TITAN network by AWS.
+  EOF
+}
+
+output "main_route_table_id" {
+  value = "${aws_vpc.default.main_route_table_id}"
+
+  description = <<-EOF
+    The ID of the main route table created by default by AWS for this TITAN network.
+  EOF
+}
+
+output "netbios_name_servers" {
+  value = ["${var.netbios_name_servers}"]
+
+  description = <<-EOF
+    The NetBIOS name servers for this TITAN network.
+  EOF
+}
+
+output "netbios_node_type" {
+  value = "${var.netbios_node_type}"
+
+  description = <<-EOF
+    The NetBIOS node type (1, 2, 4, or 8).
+  EOF
+}
+
+output "network_id" {
+  value = "${var.network_id}"
+
+  description = <<-EOF
+    The second IP octet uniquely identifiing this TITAN network.
+  EOF
+}
+
+output "ntp_servers" {
+  value = ["${var.ntp_servers}"]
+
+  description = <<-EOF
+    A list of up to four NTP servers broadcast to hosts via DHCP within this TITAN network.
+  EOF
+}
+
+output "octet_0" {
+  value = "10"
+
+  description = <<-EOF
+    The first octet of this TITAN network's space.
+
+    In compliance with RFC 1918, the first octet is hard-coded to 10, as this is the only reserved address block which
+    is a `/8` dedicated to private networking.
+  EOF
+}
+
+output "octet_1" {
+  value = "${var.network_id}"
+
+  description = <<-EOF
+    Synonym for `network_id`, the second IP octet uniquely identifying this TITAN network.
+  EOF
+}
+
+output "subnets_per_layer" {
+  value = "${var.subnets_per_layer}"
+
+  description = <<-EOF
+    The amount of subnets contained in a single TITAN layer for this network.
+  EOF
+}
+
+output "vpc_id" {
+  value = "${aws_vpc.default.id}"
+
+  description = <<-EOF
+    VPC identifier for this TITAN network.
+  EOF
+}

--- a/modules/aws/titan_network/outputs.tf
+++ b/modules/aws/titan_network/outputs.tf
@@ -1,0 +1,50 @@
+# TITAN Network Module - Outputs
+
+output "account_id" {
+  value = "${data.aws_caller_identity.default.account_id}"
+
+  description = <<-EOF
+    The AWS account id in which this TITAN network lives.
+  EOF
+}
+
+output "availability_zones" {
+  value = ["${slice(data.aws_availability_zones.default.names, 0, var.subnets_per_layer)}"]
+
+  description = <<-EOF
+    The availability zones which this TITAN network occupies. The length of this list is set by the `subnets_per_layer`
+    variable.
+  EOF
+}
+
+output "name" {
+  value = "${var.name}"
+
+  description = <<-EOF
+    Long name of the TITAN network.
+  EOF
+}
+
+output "name_fancy" {
+  value = "${var.name_fancy}"
+
+  description = <<-EOF
+    "Fancy" name for the TITAN network.
+  EOF
+}
+
+output "name_short" {
+  value = "${var.name_short}"
+
+  description = <<-EOF
+    Short name of the TITAN network.
+  EOF
+}
+
+output "region" {
+  value = "${data.aws_region.default.name}"
+
+  description = <<-EOF
+    The AWS region in which this TITAN network lives.
+  EOF
+}

--- a/modules/aws/titan_network/r.route53.tf
+++ b/modules/aws/titan_network/r.route53.tf
@@ -1,0 +1,42 @@
+# TITAN Network Module - Route 53 Resources
+
+# Set of Name Servers for Public DNS Resolution
+resource "aws_route53_delegation_set" "default" {
+  reference_name = "${var.name_short}.${var.domain}"
+}
+
+# Public Route 53 Hosted Zone
+resource "aws_route53_zone" "public" {
+  name = "${var.name_short}.${var.domain}"
+  delegation_set_id = "${aws_route53_delegation_set.default.id}"
+
+  tags {
+    Name = "${var.name_fancy} Public Hosted Zone"
+    titan_zone = "${var.name_short}.${var.domain}"
+    titan_dns_horizon = "public"
+  }
+}
+
+# Private/Internal Route 53 Hosted Zone
+resource "aws_route53_zone" "private" {
+  name = "${var.name_short}.${var.domain}"
+  vpc_id = "${aws_vpc.default.id}"
+
+  tags {
+    Name = "${var.name_fancy} Private Hosted Zone"
+    titan_zone = "${var.name_short}.${var.domain}"
+    titan_dns_horizon = "private"
+  }
+}
+
+# Reverse Route 53 Hosted Zone
+resource "aws_route53_zone" "reverse" {
+  name = "${var.network_id}.10.in-addr.arpa"
+  vpc_id = "${aws_vpc.default.id}"
+
+  tags {
+    Name = "${var.name_fancy} Reverse Hosted Zone"
+    titan_zone = "${var.name_short}.${var.domain}"
+    titan_dns_horizon = "private"
+  }
+}

--- a/modules/aws/titan_network/r.security_groups.tf
+++ b/modules/aws/titan_network/r.security_groups.tf
@@ -1,0 +1,54 @@
+# TITAN Network Module - Security Group Resources
+
+# Default Security Group for the VPC
+# Allow SSH Internal Ingress; Egress Anywhere
+resource "aws_default_security_group" "default" {
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+    protocol  = "tcp"
+    from_port = 22
+    to_port   = 22
+    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "titan_${var.name_short}_default"
+    titan_network = "${var.name}"
+    titan_zone = "${var.name_short}.${var.domain}"
+  }
+}
+
+# Security Group Allowing Network-Internal SSH Access
+resource "aws_security_group" "ssh" {
+  name = "titan_${var.name_short}_ssh_internal"
+  description = "Network-Internal SSH Access in the ${var.name_fancy}."
+  vpc_id = "${aws_vpc.default.id}"
+
+  ingress {
+    protocol = "tcp"
+    from_port = 22
+    to_port = 22
+    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "titan_${var.name_short}_ssh_internal"
+    titan_network = "${var.name}"
+    titan_zone = "${var.name_short}.${var.domain}"
+  }
+}

--- a/modules/aws/titan_network/r.sns.tf
+++ b/modules/aws/titan_network/r.sns.tf
@@ -1,0 +1,7 @@
+# TITAN Network Module - SNS Resources
+
+# SNS Topic for Network AutoScaling Events
+resource "aws_sns_topic" "autoscaling" {
+  name = "titan_${var.name_short}_autoscaling_topic"
+  display_name = "SNS Notification Topic for Auto-Scaling Events in the ${var.name_fancy}."
+}

--- a/modules/aws/titan_network/r.vpc.tf
+++ b/modules/aws/titan_network/r.vpc.tf
@@ -1,0 +1,63 @@
+# TITAN Network Module - VPC Resources
+
+# VPC
+resource "aws_vpc" "default" {
+  cidr_block = "10.${var.network_id}.0.0/16"
+  instance_tenancy = "${var.instance_tenancy}"
+
+  assign_generated_ipv6_cidr_block = true
+
+  enable_classiclink = false
+  enable_dns_hostnames = true
+  enable_dns_support = true
+
+  tags {
+    Name = "${var.name_short}.${var.domain}"
+    titan_network = "${var.name}"
+    titan_zone = "${var.name_short}.${var.domain}"
+  }
+}
+
+# The VPC's DHCP Options Set
+resource "aws_vpc_dhcp_options" "default" {
+  domain_name = "${var.name_short}.${var.domain}"
+
+  domain_name_servers = ["${var.domain_name_servers}"]
+
+  ntp_servers = ["${var.ntp_servers}"]
+
+  netbios_name_servers = ["${var.netbios_name_servers}"]
+  netbios_node_type = "${var.netbios_node_type}"
+
+  tags {
+    Name = "${var.name_short}.${var.domain}"
+    titan_network = "${var.name}"
+    titan_zone = "${var.name_short}.${var.domain}"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Associate the DHCP Options Set with the VPC
+resource "aws_vpc_dhcp_options_association" "default" {
+  vpc_id = "${aws_vpc.default.id}"
+  dhcp_options_id = "${aws_vpc_dhcp_options.default.id}"
+}
+
+# Internet Gateway for the VPC (IPv4)
+resource "aws_internet_gateway" "default" {
+  vpc_id = "${aws_vpc.default.id}"
+
+  tags {
+    Name = "${var.name_short}.${var.domain}"
+    titan_network = "${var.name}"
+    titan_zone = "${var.name_short}.${var.domain}"
+  }
+}
+
+# Egress-Only Internet Gateway for the VPC (IPv6)
+resource "aws_egress_only_internet_gateway" "default" {
+  vpc_id = "${aws_vpc.default.id}"
+}

--- a/modules/aws/titan_network/r.vpce.tf
+++ b/modules/aws/titan_network/r.vpce.tf
@@ -1,0 +1,1 @@
+# TITAN Network Module - VPC Endpoint Resources

--- a/modules/aws/titan_network/v.route53.tf
+++ b/modules/aws/titan_network/v.route53.tf
@@ -1,0 +1,12 @@
+# TITAN Network Module - Route 53 Variables
+
+variable "domain" {
+  description = <<-EOF
+    The base domain to derive network hosted zones from.
+
+    Usually, this value is set to something like `mydomain.com`, yielding hosted zones for environments like
+    `dev.mydomain.com`, `stg.mydomain.com`, and `prod.mydomain.com`.
+
+    Examples: `mydomain.com`, `mycompanydomain.com`, `uswest1.mydomain.com`. 
+  EOF
+}

--- a/modules/aws/titan_network/v.vpc.tf
+++ b/modules/aws/titan_network/v.vpc.tf
@@ -1,0 +1,100 @@
+# TITAN Network Module - VPC Variables
+
+variable "domain_name_servers" {
+  type = "list"
+  default = ["AmazonProvidedDNS"]
+
+  description = <<-EOF
+    A list of up to three DNS resolvers to be broadcast to hosts on the network via DHCP. Pass additional IP addresses
+    or DNS names (with an understanding of the consequences) to specify outside DNS resolvers.
+
+    Default: `AmazonProvidedDNS` - Route 53 internal resolver.
+
+    See: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html
+  EOF
+}
+
+variable "instance_tenancy" {
+  default = "default"
+
+  description = <<-EOF
+    Instance tenancy for EC2 instances launched in this TITAN network's VPC.
+
+    Default: `default`.
+
+    See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html
+  EOF
+}
+
+variable "netbios_name_servers" {
+  type = "list"
+  default = []
+
+  description = <<-EOF
+    A list of up to four IP addressses of NetBIOS name servers.
+
+    See: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html
+  EOF
+}
+
+variable "netbios_node_type" {
+  default = 2
+
+  description = <<-EOF
+    The NetBIOS node type (1, 2, 4, or 8).
+
+    It is recommended that this be left with a default of 2.
+
+    See: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html
+  EOF
+}
+
+variable "network_id" {
+  description = <<-EOF
+    The second octet to use for this TITAN network.
+
+    In compliance with RFC 1918, the first octet is hard-coded to 10, as this is the only reserved address block which
+    is a `/8` dedicated to private networking. This `network_id` is the second octet and is used to create a `/16` for
+    this TITAN network.
+  EOF
+}
+
+variable "ntp_servers" {
+  type = "list"
+  default = [
+    "0.amazon.pool.ntp.org",
+    "1.amazon.pool.ntp.org",
+    "2.amazon.pool.ntp.org",
+    "3.amazon.pool.ntp.org"
+  ]
+
+  description = <<-EOF
+    A list of up to four NTP servers to be broadcast to hosts on the network via DHCP.
+
+    **NOTE:** Amazon offers a completely internal NTP server in every region at 169.254.169.123. However, as per the
+    documentation linked below, it is lacking support for M5 and C5 instances at present. Therefore, we default to using
+    NTP servers that are accessible over WAN and still managed by Amazon. Local, in-region NTP is preferable to access
+    over WAN, but lack of support for certain instance types led to this design decision in TITAN.
+
+    Default: Use Amazon's external WAN-facing NTP pool for EC2.
+
+    See:
+      - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html
+      - https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_DHCP_Options.html
+  EOF
+}
+
+variable "subnets_per_layer" {
+  default = "3"
+
+  description = <<-EOF
+    The amount of subnets to create per layer. TITAN layers are composed of this number of subnets distributed across
+    availability zones.
+
+    **NOTE:** Think carefully before changing this value. At minimum, it is advisable to leave this at the default of
+    3. At maximum, 5 subnets are supported as layers are offset by ten values in the third octet and most subnets are
+    /23s.
+
+    Default: 3
+  EOF
+}

--- a/modules/aws/titan_network/variables.tf
+++ b/modules/aws/titan_network/variables.tf
@@ -1,0 +1,32 @@
+# TITAN Network Module - Variables
+
+variable "name" {
+  description = <<-EOF
+    Long name of the TITAN network.
+
+    This value serves as a unique identifier between different TITAN networks and is used in tagging resources.
+
+    Examples: `development`, `staging`, `production`.
+  EOF
+}
+
+variable "name_short" {
+  description = <<-EOF
+    Short name of the TITAN network.
+
+    This value serves as the first segment of the DNS hosted zone for the given TITAN network, e.g `dev.${var.domain}`.
+
+    Examples: `dev`, `stg`, `prod`.
+  EOF
+}
+
+variable "name_fancy" {
+  description = <<-EOF
+    "Fancy" name for the TITAN network.
+
+    This value is used in formatting human-readable descriptions of resources related to the given TITAN network.
+
+    Examples: `TITAN Development Environment`, `TITAN Hub`, `TITAN Staging Environment`,
+    `TITAN Production Environment`.
+  EOF
+}

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: naftulikay.terraform
+- src: naftulikay.vagrant-base

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,0 +1,17 @@
+---
+- name: build
+  hosts: all
+  become: true
+  roles:
+    - role: naftulikay.terraform
+      version: 0.11.1
+    - role: naftulikay.vagrant-base
+  tasks:
+    - name: allow aws environment variables across the wire
+      lineinfile:
+        dest: /etc/ssh/sshd_config
+        line: AcceptEnv AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+      notify: restart ssh
+  handlers:
+    - name: restart ssh
+      service: name=sshd state=restarted


### PR DESCRIPTION
Initial work on the main network module.

## Network

### Generic

 - [x] Export AWS region.

### ACL

 - [ ] Default ACL permit ingress/egress everywhere at the highest rule value.

### EFS

 - [ ] Network-global EFS volume `efs-${az}`.
 - [ ] One mount per subnet/availability zone.
 - [ ] DNS names for each mount.

### VPC Endpoint

 - [ ] S3 VPC Endpoint
 - [ ] Routes to S3 via VPC endpoint.

### IPv4

 - [ ] 3x NAT Gateways associated with public subnets (DMZ).
 - [ ] `0.0.0.0/0` route for public subnets via Internet Gateway.
 - [ ] `0.0.0.0/0` route for private subnets via NAT Gateway.

### IPv6

 - [ ] `::/0` route for public subnets via Internet Gateway.
 - [ ] `::/0` route for private subnets via Egress-Only Internet Gateway.

## Layer

 - [ ] 3x Subnets.
 - [ ] 1x Route Table per Subnet (different summary routes for each availability zone to its adjacent NAT Gateway).
 - [ ] 1x Network ACL per Layer, shared between subnets, allow all ingress/egress at .

## Environment

 - [ ] VPC peering connection to hub.
 - [ ] Routes for all route tables back to hub over VPC peering connection.

## Hub

Nothing differs between TITAN Network and TITAN Hub.