### PR TITLE
TITAN Layer Module

### DIFF
--- a/modules/aws/titan_layer/main.tf
+++ b/modules/aws/titan_layer/main.tf
@@ -1,0 +1,1 @@
+# TITAN Layer Module

--- a/modules/aws/titan_layer/o.network_acl.tf
+++ b/modules/aws/titan_layer/o.network_acl.tf
@@ -1,0 +1,9 @@
+# TITAN Layer Module - Network ACL Outputs
+
+output "network_acl_id" {
+  value = "${aws_network_acl.default.id}"
+
+  description = <<-EOF
+    The id of the network ACL shared by all subnets in this TITAN layer.
+  EOF
+}

--- a/modules/aws/titan_layer/o.routing.tf
+++ b/modules/aws/titan_layer/o.routing.tf
@@ -1,0 +1,43 @@
+# TITAN Layer Module - Routing Outputs
+
+output "egress_only_gateway_id" {
+  value = "${var.egress_only_gateway_id}"
+
+  description = <<-EOF
+    The Egress-Only Internet Gateway id for the host TITAN network.
+
+    This will be undefined for public layers.
+  EOF
+}
+
+output "internet_gateway_id" {
+  value = "${var.internet_gateway_id}"
+
+  description = <<-EOF
+    The Internet Gateway id for the host TITAN network.
+
+    This will be undefined for private layers.
+  EOF
+}
+
+output "nat_gateway_ids" {
+  value = ["${var.nat_gateway_ids}"]
+
+  description = <<-EOF
+    A list of NAT Gateway ids, one per availability zone, of the host TITAN network.
+
+    This will be undefined for public layers.
+  EOF
+}
+
+output "route_table_ids" {
+  value = ["${aws_route_table.default.*.id}"]
+
+  description = <<-EOF
+    A list of route table ids for each subnet in this TITAN layer.
+
+    The length of this list will match the length of the `availability_zones` list variable and output, as one subnet
+    is created per availability zone. Additionally, the first route table in `route_table_ids` will target the subnet
+    in the first availability zone in `availability_zones`.
+  EOF
+}

--- a/modules/aws/titan_layer/o.subnet.tf
+++ b/modules/aws/titan_layer/o.subnet.tf
@@ -1,0 +1,81 @@
+# TITAN Layer Module - Subnet Outputs
+
+output "cidr_blocks" {
+  value = ["${aws_subnet.default.*.cidr_block}"]
+
+  description = <<-EOF
+    A list of the IPv4 CIDR blocks for each subnet in this TITAN layer.
+
+    The length of this list will match the length of the `availability_zones` list variable and output, as one subnet
+    is created per availability zone. Additionally, the first CIDR block in `cidr_blocks` will be in the first
+    availability zone in `availability_zones`.
+  EOF
+}
+
+output "cidr_mask_bits" {
+  value = "${var.cidr_mask_bits}"
+
+  description = <<-EOF
+    Number of bits to extend per subnet into the host network's /16.
+  EOF
+}
+
+output "cidr_start" {
+  value = "${var.cidr_start}"
+
+  description = <<-EOF
+    The third IPv4 octet which subnets are sequentially numbered from.
+  EOF
+}
+
+output "ipv6_association_ids" {
+  value = ["${aws_subnet.default.*.ipv6_association_ids}"]
+
+  description = <<-EOF
+    A list of the IPv6 association ids for each subnet in this TITAN layer.
+
+    The length of this list will match the length of the `availability_zones` list variable and output, as one subnet
+    is created per availability zone. Additionally, the first id in `ipv6_association_ids` will be in the first
+    availability zone in `availability_zones`.
+  EOF
+}
+
+output "ipv6_cidr_blocks" {
+  value = ["${aws_subnet.default.*.ipv6_cidr_blocks}"]
+
+  description = <<-EOF
+    A list of IPv6 CIDR blocks for each subnet in this TITAN layer.
+
+    The length of this list will match the length of the `availability_zones` list variable and output, as one subnet
+    is created per availability zone. Additionally, the first CIDR block in `ipv6_cidr_blocks` will be in the first
+    availability zone in `availability_zones`.
+  EOF
+}
+
+output "network_cidr_block" {
+  value = "${var.network_cidr_block}"
+
+  description = <<-EOF
+    The IPv4 CIDR block of the host TITAN network.
+  EOF
+}
+
+output "network_ipv6_cidr_block" {
+  value = "${var.network_ipv6_cidr_block}"
+
+  description = <<-EOF
+    The IPv6 CIDR block of the host TITAN network.
+  EOF
+}
+
+output "subnet_ids" {
+  value = ["${aws_subnet.default.*.id}"]
+
+  description = <<-EOF
+    A list of the subnet ids which belong to this TITAN layer.
+
+    The length of this list will match the length of the `availability_zones` list variable and output, as one subnet
+    is created per availability zone. Additionally, the first subnet in `subnet_ids` will be in the first availability
+    zone in `availability_zones`.
+  EOF
+}

--- a/modules/aws/titan_layer/outputs.tf
+++ b/modules/aws/titan_layer/outputs.tf
@@ -1,0 +1,49 @@
+# TITAN Layer Module - Outputs
+
+output "availability_zones" {
+  value = ["${var.availability_zones}"]
+
+  description = <<-EOF
+    The availability zones supported by the subnets in this TITAN layer.
+  EOF
+}
+
+output "is_public" {
+  value = "${var.is_public}"
+
+  description = <<-EOF
+    Whether the layer is public-facing or is private behind NAT.
+  EOF
+}
+
+output "name" {
+  value = "${var.name}"
+
+  description = <<-EOF
+    The name of this TITAN layer.
+  EOF
+}
+
+output "network_name" {
+  value = "${var.network_name}"
+
+  description = <<-EOF
+    The name of the TITAN Network to which this layer belongs.
+  EOF
+}
+
+output "vpc_id" {
+  value = "${var.vpc_id}"
+
+  description = <<-EOF
+    The VPC id of the TITAN network owning this TITAN layer.
+  EOF
+}
+
+output "zone" {
+  value = "${var.zone}"
+
+  description = <<-EOF
+    The hosted zone of the TITAN Network to which this layer belongs.
+  EOF
+}

--- a/modules/aws/titan_layer/r.network_acl.tf
+++ b/modules/aws/titan_layer/r.network_acl.tf
@@ -1,0 +1,39 @@
+# TITAN Layer Module - Network ACL Resources
+
+# Network ACL Shared by All Subnets in the Layer
+resource "aws_network_acl" "default" {
+  vpc_id = "${var.vpc_id}"
+  subnet_ids = ["${aws_subnet.default.*.id}"]
+
+  # tags
+  tags {
+    Name = "${var.name}.${var.zone}"
+    titan_layer = "${var.name}"
+    titan_network = "${var.network_name}"
+    titan_zone = "${var.zone}"
+  }
+}
+
+# Default Ingress Rule: Allow All (Override by Lower Priority Rule)
+resource "aws_network_acl_rule" "ingress" {
+  network_acl_id = "${aws_network_acl.default.id}"
+
+  egress = false
+  rule_number = 1000
+  protocol = "all"
+  rule_action = "allow"
+  cidr_block = "0.0.0.0/0"
+  ipv6_cidr_block = "::/0"
+}
+
+# Default Egress Rule: Allow All (Override by Lower Priority Rule)
+resource "aws_network_acl_rule" "egress" {
+  network_acl_id = "${aws_network_acl.default.id}"
+
+  egress = true
+  rule_number = 1000
+  protocol = "all"
+  rule_action = "allow"
+  cidr_block = "0.0.0.0/0"
+  ipv6_cidr_block = "::/0"
+}

--- a/modules/aws/titan_layer/r.routing.tf
+++ b/modules/aws/titan_layer/r.routing.tf
@@ -1,0 +1,54 @@
+# TITAN Layer Module - Routing Resources
+
+# Route Table for Each Subnet
+resource "aws_route_table" "default" {
+  count = "${length(var.availability_zones)}"
+
+  vpc_id = "${var.vpc_id}"
+
+  # tags
+  tags {
+    Name = "${var.name}-${count.index}.${var.zone}"
+    titan_layer = "${var.name}"
+    titan_network = "${var.network_name}"
+    titan_zone = "${var.zone}"
+  }
+}
+
+resource "aws_route_table_association" "default" {
+  count = "${length(var.availability_zones)}"
+
+  subnet_id = "${element(aws_subnet.default.*.id, count.index)}"
+  route_table_id = "${element(aws_route_table.default.*.id, count.index)}"
+}
+
+# Route for Public, WAN-Facing Layers
+resource "aws_route" "public" {
+  # only created for public layers
+  count = "${var.is_public ? length(var.availability_zones) : 0}"
+
+  route_table_id = "${element(aws_route_table.default.*.id, count.index)}"
+  gateway_id = "${var.internet_gateway_id}"
+  destination_cidr_block = "0.0.0.0/0"
+  destination_ipv6_cidr_block = "::/0"
+}
+
+# Route for Private, NAT Layers
+resource "aws_route" "private" {
+  # only created for private layers
+  count = "${var.is_public ? 0 : length(var.availability_zones)}"
+
+  route_table_id = "${element(aws_route_table.default.*.id, count.index)}"
+  # there must be one NAT gateway per availability zone, hence 1:1 route table to NAT gateway
+  nat_gateway_id = "${var.nat_gateway_ids[count.index]}"
+  destination_cidr_block = "0.0.0.0/0"
+}
+
+resource "aws_route" "private_ipv6" {
+  # only created for private layers
+  count = "${var.is_public ? 0 : length(var.availability_zones)}"
+
+  route_table_id = "${element(aws_route_table.default.*.id, count.index)}"
+  egress_only_gateway_id = "${var.egress_only_gateway_id}"
+  destination_ipv6_cidr_block = "::/0"
+}

--- a/modules/aws/titan_layer/r.subnet.tf
+++ b/modules/aws/titan_layer/r.subnet.tf
@@ -1,0 +1,22 @@
+# TITAN Layer Module - Subnet Resources
+
+resource "aws_subnet" "default" {
+  count = "${length(var.availability_zones)}"
+
+  vpc_id = "${var.vpc_id}"
+
+  availability_zone = "${element(var.availability_zones, count.index)}"
+  cidr_block = "${cidrsubnet("${var.network_cidr_block}", var.cidr_mask_bits, var.cidr_start + count.index)}"
+  ipv6_cidr_block = "${cidrsubnet(var.network_ipv6_cidr_block, 10, var.cidr_start + count.index)}"
+
+  map_public_ip_on_launch = "${var.is_public}"
+  assign_ipv6_address_on_creation = true
+
+  # tags
+  tags {
+    Name = "${var.name}-${count.index}.${var.zone}"
+    titan_layer = "${var.name}"
+    titan_network = "${var.network_name}"
+    titan_zone = "${var.zone}"
+  }
+}

--- a/modules/aws/titan_layer/v.routing.tf
+++ b/modules/aws/titan_layer/v.routing.tf
@@ -1,0 +1,32 @@
+# TITAN Layer Module - Routing Variables
+
+variable "egress_only_gateway_id" {
+  default = ""
+
+  description = <<-EOF
+    The Egress-Only Internet Gateway of the TITAN network owning this layer.
+
+    This value is required for private layers and ignored for public layers.
+  EOF
+}
+
+variable "internet_gateway_id" {
+  default = ""
+
+  description = <<-EOF
+    The Internet Gateway id of the TITAN network owning this layer.
+
+    This value is required for public layers and ignored for private layers.
+  EOF
+}
+
+variable "nat_gateway_ids" {
+  type = "list"
+  default = []
+
+  description = <<-EOF
+    A list of NAT Gateway ids, one per availability zone, of the TITAN network owning this layer.
+
+    This value is required for private layers and ignored for public layers.
+  EOF
+}

--- a/modules/aws/titan_layer/v.subnet.tf
+++ b/modules/aws/titan_layer/v.subnet.tf
@@ -1,0 +1,44 @@
+# TITAN Layer Module - Subnet Variables
+
+variable "cidr_mask_bits" {
+  default = "7"
+
+  description = <<-EOF
+    Number of bits to extend per subnet into the host network's /16.
+
+    This is kind of a confusing value, but to make things easy, only 7 and 8 are supported and result in a /23 and a
+    /24, respectively. This is used with the `cidrsubnet()` configuration function as the `newbits` parameter.
+
+    Default: 7, yielding up to 512 addresses per subnet in the layer.
+
+    See: https://www.terraform.io/docs/configuration/interpolation.html#cidrsubnet-iprange-newbits-netnum-
+  EOF
+}
+
+variable "cidr_start" {
+  description = <<-EOF
+    The third IPv4 octet to begin numbering layer subnets from.
+
+    Generally, to accommodate up to 5 availability zones per layer at /23 subnet size, this value should be a multiple
+    of ten, e.g. `0`, `10`, `20`, etc. This is used with the `cidrsubnet()` configuration function as the `netnum`
+    parameter.
+
+    See: https://www.terraform.io/docs/configuration/interpolation.html#cidrsubnet-iprange-newbits-netnum-
+  EOF
+}
+
+variable "network_cidr_block" {
+  description = <<-EOF
+    The IPv4 CIDR block of the host TITAN network.
+
+    This should always be a /16.
+  EOF
+}
+
+variable "network_ipv6_cidr_block" {
+  description = <<-EOF
+    The IPv6 CIDR block for the host TITAN network.
+
+    This should always be a /56.
+  EOF
+}

--- a/modules/aws/titan_layer/variables.tf
+++ b/modules/aws/titan_layer/variables.tf
@@ -1,0 +1,43 @@
+# TITAN Layer Module - Variables
+
+variable "availability_zones" {
+  type = "list"
+
+  description = <<-EOF
+    A list of availability zones to distribute subnets along.
+  EOF
+}
+
+variable "is_public" {
+  default = false
+
+  description = <<-EOF
+    Does this layer face WAN, or is it private?
+
+    Default: false.
+  EOF
+}
+
+variable "name" {
+  description = <<-EOF
+    The name of this TITAN layer.
+  EOF
+}
+
+variable "network_name" {
+  description = <<-EOF
+    The name of the TITAN Network to which this layer belongs.
+  EOF
+}
+
+variable "vpc_id" {
+  description = <<-EOF
+    The VPC id of the TITAN network owning this TITAN layer.
+  EOF
+}
+
+variable "zone" {
+  description = <<-EOF
+    The hosted zone of the TITAN Network to which this layer belongs.
+  EOF
+}

--- a/modules/aws/titan_network/r.vpce.tf
+++ b/modules/aws/titan_network/r.vpce.tf
@@ -1,1 +1,0 @@
-# TITAN Network Module - VPC Endpoint Resources


### PR DESCRIPTION
### Validation

 - [x] All variables are exported as outputs.
 - [x] All subnet attributes are exported as outputs.
 - [x] All route table attributes are exported as outputs.
 - [x] All NACL attributes are exported as outputs.

Closes #14, #13, #12, #11, #10, #9.