### PR TITLE
[WIP] GCP Service Activations in Example

### DIFF
--- a/examples/gcp/v0/1/default/main.tf
+++ b/examples/gcp/v0/1/default/main.tf
@@ -19,9 +19,20 @@ module "network" {
 
   nat_additional_ssh_cidr_blocks = ["0.0.0.0/0"]
   nat_additional_startup_script = "${file("${path.module}/init.sh")}"
+
+  depends_on = ["${google_project_services.default.project}"]
 }
 
-data "google_compute_zones" "available" {}
+data "google_client_config" "default" {}
+
+resource "google_project_services" "default" {
+  project = "${data.google_client_config.default.project}"
+  services = ["compute.googleapis.com", "dns.googleapis.com"]
+}
+
+data "google_compute_zones" "available" {
+  depends_on = ["google_project_services.default"]
+}
 
 resource "google_compute_instance" "admin" {
   count = 3

--- a/modules/gcp/v0/1/titan_network/main.tf
+++ b/modules/gcp/v0/1/titan_network/main.tf
@@ -4,3 +4,5 @@ locals {
   cidr_block = "10.${var.id}.0.0/16"
   zone = "${var.name_short}.${var.domain}"
 }
+
+variable "depends_on" { type = "list" default = [] }


### PR DESCRIPTION
Provide an example which covers service activations for Google Cloud. Until services are activated, Terraform will fail to get things like availability zones or DNS, which is bad.

Closes #49 if merged.

cc @blackstar257