### PR TITLE
Optional NAT

### DIFF
--- a/examples/aws/v1/single-no-nat/Makefile
+++ b/examples/aws/v1/single-no-nat/Makefile
@@ -1,0 +1,4 @@
+#!/usr/bin/make -f
+
+clean:
+	@rm -fr .terraform.lock.hcl .terraform terraform.tfstate

--- a/examples/aws/v1/single-no-nat/main.tf
+++ b/examples/aws/v1/single-no-nat/main.tf
@@ -1,0 +1,22 @@
+# Single, Small-Sized (1 AZ) Titan Network Example
+
+provider "aws" {
+  region = "us-east-1"
+}
+
+terraform {
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+module "network" {
+  source = "../../../../modules/aws/v1/titan_network"
+  network_id = 1
+  name = "development"
+  name_short = "dev"
+  name_fancy = "Titan Development Network"
+  nat_enabled = false
+  domain = "us-east-1.mycompany.com"
+  subnets_per_layer = 1
+}

--- a/modules/aws/v1/titan_environment/exports/outputs.tf
+++ b/modules/aws/v1/titan_environment/exports/outputs.tf
@@ -56,6 +56,7 @@ output name_fancy { value = module.environment.name_fancy }
 output name_short { value = module.environment.name_short }
 output name { value = module.environment.name }
 output nat_allocation_ids { value = module.environment.nat_allocation_ids }
+output nat_enabled { value = module.environment.nat_enabled }
 output nat_gateway_ids { value = module.environment.nat_gateway_ids }
 output nat_interface_ids { value = module.environment.nat_interface_ids }
 output nat_private_ips { value = module.environment.nat_private_ips }

--- a/modules/aws/v1/titan_environment/main.tf
+++ b/modules/aws/v1/titan_environment/main.tf
@@ -9,6 +9,7 @@ module "network" {
   name = var.name
   name_fancy = var.name_fancy
   name_short = var.name_short
+  nat_enabled = var.nat_enabled
   netbios_name_servers = var.netbios_name_servers
   network_id = var.network_id
   ntp_servers = var.ntp_servers

--- a/modules/aws/v1/titan_environment/o.network.tf
+++ b/modules/aws/v1/titan_environment/o.network.tf
@@ -50,6 +50,7 @@ output name_fancy { value = module.network.name_fancy }
 output name_short { value = module.network.name_short }
 output name { value = module.network.name }
 output nat_allocation_ids { value = module.network.nat_allocation_ids }
+output nat_enabled { value = module.network.nat_enabled }
 output nat_gateway_ids { value = module.network.nat_gateway_ids }
 output nat_interface_ids { value = module.network.nat_interface_ids }
 output nat_private_ips { value = module.network.nat_private_ips }

--- a/modules/aws/v1/titan_environment/v.network.tf
+++ b/modules/aws/v1/titan_environment/v.network.tf
@@ -16,6 +16,15 @@ variable name {}
 variable name_fancy {}
 variable name_short {}
 
+variable nat_enabled {
+  type = bool
+  default = true
+
+  description = <<-EOF
+    Whether to create NAT gateways and relevant routes and resources.
+  EOF
+}
+
 variable netbios_name_servers {
   type = list(string)
   default = []

--- a/modules/aws/v1/titan_hub/exports/outputs.tf
+++ b/modules/aws/v1/titan_hub/exports/outputs.tf
@@ -49,6 +49,7 @@ output name_fancy { value = module.hub.name_fancy }
 output name_short { value = module.hub.name_short }
 output name { value = module.hub.name }
 output nat_allocation_ids { value = module.hub.nat_allocation_ids }
+output nat_enabled { value = module.hub.nat_enabled }
 output nat_gateway_ids { value = module.hub.nat_gateway_ids }
 output nat_interface_ids { value = module.hub.nat_interface_ids }
 output nat_private_ips { value = module.hub.nat_private_ips }

--- a/modules/aws/v1/titan_hub/main.tf
+++ b/modules/aws/v1/titan_hub/main.tf
@@ -9,6 +9,7 @@ module "network" {
   name = var.name
   name_fancy = var.name_fancy
   name_short = var.name_short
+  nat_enabled = var.nat_enabled
   netbios_name_servers = var.netbios_name_servers
   network_id = var.network_id
   ntp_servers = var.ntp_servers

--- a/modules/aws/v1/titan_hub/o.network.tf
+++ b/modules/aws/v1/titan_hub/o.network.tf
@@ -50,6 +50,7 @@ output name_fancy { value = module.network.name_fancy }
 output name_short { value = module.network.name_short }
 output name { value = module.network.name }
 output nat_allocation_ids { value = module.network.nat_allocation_ids }
+output nat_enabled { value = module.network.nat_enabled }
 output nat_gateway_ids { value = module.network.nat_gateway_ids }
 output nat_interface_ids { value = module.network.nat_interface_ids }
 output nat_private_ips { value = module.network.nat_private_ips }

--- a/modules/aws/v1/titan_hub/v.network.tf
+++ b/modules/aws/v1/titan_hub/v.network.tf
@@ -16,6 +16,15 @@ variable name {}
 variable name_fancy {}
 variable name_short {}
 
+variable nat_enabled {
+  type = bool
+  default = true
+
+  description = <<-EOF
+    Whether to create NAT gateways and relevant routes and resources.
+  EOF
+}
+
 variable netbios_name_servers {
   type = list(string)
   default = []

--- a/modules/aws/v1/titan_layer/exports/outputs.tf
+++ b/modules/aws/v1/titan_layer/exports/outputs.tf
@@ -10,6 +10,7 @@ output ipv6_cidr_block_association_ids { value = module.layer.ipv6_cidr_block_as
 output ipv6_cidr_blocks { value = module.layer.ipv6_cidr_blocks }
 output is_public { value = module.layer.is_public }
 output name { value = module.layer.name }
+output nat_enabled { value = module.layer.nat_enabled }
 output nat_gateway_ids { value = module.layer.nat_gateway_ids }
 output network_acl_id { value = module.layer.network_acl_id }
 output network_cidr_block { value = module.layer.network_cidr_block }

--- a/modules/aws/v1/titan_layer/o.nat.tf
+++ b/modules/aws/v1/titan_layer/o.nat.tf
@@ -1,0 +1,9 @@
+# Titan Layer Module - NAT Outputs
+
+output nat_enabled {
+  value = var.nat_enabled
+
+  description = <<-EOF
+    Whether NAT gateways and relevant resources are created.
+  EOF
+}

--- a/modules/aws/v1/titan_layer/r.routing.tf
+++ b/modules/aws/v1/titan_layer/r.routing.tf
@@ -43,8 +43,8 @@ resource aws_route public_ipv6 {
 
 # Route for Private, NAT Layers
 resource aws_route private {
-  # only created for private layers
-  count = var.is_public ? 0 : length(var.availability_zones)
+  # only created for private layers when nat is enabled
+  count = var.is_public || !var.nat_enabled ? 0 : length(var.availability_zones)
 
   route_table_id = aws_route_table.default[count.index].id
   # there must be one NAT gateway per availability zone, hence 1:1 route table to NAT gateway

--- a/modules/aws/v1/titan_layer/v.nat.tf
+++ b/modules/aws/v1/titan_layer/v.nat.tf
@@ -1,0 +1,10 @@
+# Titan Layer Module - Routing Variables
+
+variable nat_enabled {
+  type = bool
+  default = true
+
+  description = <<-EOF
+    Whether to create NAT gateways and relevant routes and resources.
+  EOF
+}

--- a/modules/aws/v1/titan_network/exports/outputs.tf
+++ b/modules/aws/v1/titan_network/exports/outputs.tf
@@ -49,6 +49,7 @@ output name_fancy { value = module.network.name_fancy }
 output name_short { value = module.network.name_short }
 output name { value = module.network.name }
 output nat_allocation_ids { value = module.network.nat_allocation_ids }
+output nat_enabled { value = moudle.network.nat_enabled }
 output nat_gateway_ids { value = module.network.nat_gateway_ids }
 output nat_interface_ids { value = module.network.nat_interface_ids }
 output nat_private_ips { value = module.network.nat_private_ips }

--- a/modules/aws/v1/titan_network/o.nat.tf
+++ b/modules/aws/v1/titan_network/o.nat.tf
@@ -1,5 +1,13 @@
 # Titan Network Module - NAT Gateway Outputs
 
+output nat_enabled {
+  value = var.nat_enabled
+
+  description = <<-EOF
+    Whether NAT gateways and relevant resources are created.
+  EOF
+}
+
 output nat_allocation_ids {
   value = aws_nat_gateway.default.*.allocation_id
 

--- a/modules/aws/v1/titan_network/r.layers.tf
+++ b/modules/aws/v1/titan_network/r.layers.tf
@@ -14,6 +14,7 @@ module "dmz_layer" {
   zone = "${var.name_short}.${var.domain}"
   internet_gateway_id = aws_internet_gateway.default.id
   cidr_start = 0 * 5
+  nat_enabled = var.nat_enabled
 }
 
 # The Routing Layer: Layer 5 and Layer 7 Routing
@@ -29,6 +30,7 @@ module "routing_layer" {
   zone = "${var.name_short}.${var.domain}"
   cidr_start = 1 * 5
   egress_only_gateway_id = aws_egress_only_internet_gateway.default.id
+  nat_enabled = var.nat_enabled
   nat_gateway_ids = aws_nat_gateway.default.*.id
 }
 
@@ -45,6 +47,7 @@ module "service_layer" {
   zone = "${var.name_short}.${var.domain}"
   cidr_start = 2 * 5
   egress_only_gateway_id = aws_egress_only_internet_gateway.default.id
+  nat_enabled = var.nat_enabled
   nat_gateway_ids = aws_nat_gateway.default.*.id
 }
 
@@ -61,6 +64,7 @@ module "data_layer" {
   zone = "${var.name_short}.${var.domain}"
   cidr_start = 3 * 5
   egress_only_gateway_id = aws_egress_only_internet_gateway.default.id
+  nat_enabled = var.nat_enabled
   nat_gateway_ids = aws_nat_gateway.default.*.id
 }
 
@@ -77,6 +81,7 @@ module "admin_layer" {
   zone = "${var.name_short}.${var.domain}"
   cidr_start = 4 * 5
   egress_only_gateway_id = aws_egress_only_internet_gateway.default.id
+  nat_enabled = var.nat_enabled
   nat_gateway_ids = aws_nat_gateway.default.*.id
 }
 
@@ -97,5 +102,6 @@ module "net_layer" {
   cidr_mask_bits = 8
 
   egress_only_gateway_id = aws_egress_only_internet_gateway.default.id
+  nat_enabled = var.nat_enabled
   nat_gateway_ids = aws_nat_gateway.default.*.id
 }

--- a/modules/aws/v1/titan_network/r.nat.tf
+++ b/modules/aws/v1/titan_network/r.nat.tf
@@ -2,7 +2,7 @@
 
 # NAT Gateways per Availability Zone
 resource aws_nat_gateway default {
-  count = var.subnets_per_layer
+  count = var.nat_enabled ? var.subnets_per_layer : 0
 
   allocation_id = aws_eip.nat[count.index].id
   subnet_id = module.dmz_layer.subnet_ids[count.index]
@@ -21,7 +21,7 @@ resource aws_nat_gateway default {
 
 # Elastic IP Allocation per NAT Gateway
 resource aws_eip nat {
-  count = var.subnets_per_layer
+  count = var.nat_enabled ? var.subnets_per_layer : 0
 
   vpc = true
 

--- a/modules/aws/v1/titan_network/r.routing.tf
+++ b/modules/aws/v1/titan_network/r.routing.tf
@@ -4,21 +4,34 @@
 resource aws_default_route_table r {
   default_route_table_id = aws_vpc.default.default_route_table_id
 
-  # IPv4 summary route via first NAT Gatweway
-  route {
-    cidr_block = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.default[0].id
-  }
-
-  # IPv6 summary route via Egress-Only Internet Gateway
-  route {
-    egress_only_gateway_id = aws_egress_only_internet_gateway.default.id
-    ipv6_cidr_block = "::/0"
-  }
-
   tags = {
     Name = "${var.name_short}.${var.domain} Default Route Table"
     titan_network = var.name
     titan_zone = "${var.name_short}.${var.domain}"
   }
+}
+
+resource aws_route ipv4_egress_nat {
+  count = var.nat_enabled ? 1 : 0
+
+  route_table_id = aws_default_route_table.r.id
+
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id = aws_nat_gateway.default[0].id
+}
+
+resource aws_route ipv4_egress_public {
+  count = var.nat_enabled ? 0 : 1
+
+  route_table_id = aws_default_route_table.r.id
+
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id = aws_internet_gateway.default.id
+}
+
+resource aws_route ipv6 {
+  route_table_id = aws_default_route_table.r.id
+
+  destination_ipv6_cidr_block = "::/0"
+  egress_only_gateway_id = aws_egress_only_internet_gateway.default.id
 }

--- a/modules/aws/v1/titan_network/v.nat.tf
+++ b/modules/aws/v1/titan_network/v.nat.tf
@@ -1,0 +1,10 @@
+# Titan Network Module - NAT Variables
+
+variable nat_enabled {
+  type = bool
+  default = true
+
+  description = <<-EOF
+    Whether to create NAT gateways and relevant routes and resources.
+  EOF
+}


### PR DESCRIPTION
This feature allows users to disable NAT gateway creation, typically for cost-savings or fully-private networks.

I have tested this by hand in with NAT enabled and disabled by creating an instance in the DMZ, shelling to it, reaching the internet, then creating an instance in the admin layer, shelling to it, and validating that it can (nat_enabled=true) or cannot (nat_enabled=false) reach the internet.